### PR TITLE
feat(ui): add custom recipe node mockup

### DIFF
--- a/src/lib/components/shared/StageRecipeChain.svelte
+++ b/src/lib/components/shared/StageRecipeChain.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import RecipeNode from '@/lib/components/shared/stage/RecipeNode.svelte';
 	import type { RecipeVariant } from '@/lib/models/recipe';
 	import active from '@/lib/stores/active.svelte';
 	import dagre from '@dagrejs/dagre';
@@ -17,9 +18,12 @@
 	let nodes = $state.raw<Node[]>([]);
 	let edges = $state.raw<Edge[]>([]);
 
+	const nodeTypes = { recipe: RecipeNode };
+
 	// generate nodes
 	nodes = recipeChain.map(x => ({
 		id: x.id,
+		type: 'recipe',
 		position: { x: 0, y: 0 },
 		data: { label: x.id },
 	}));
@@ -93,6 +97,7 @@
 <SvelteFlow
 	bind:nodes
 	bind:edges
+	{nodeTypes}
 	proOptions={{ hideAttribution: true }}
 	nodesConnectable={false}
 	deleteKey={null}

--- a/src/lib/components/shared/stage/RecipeNode.svelte
+++ b/src/lib/components/shared/stage/RecipeNode.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import active from '@/lib/stores/active.svelte';
+	import { FactoryIcon } from '@lucide/svelte';
+	import { Handle, Position, type NodeProps } from '@xyflow/svelte';
+
+	let {
+		data,
+		targetPosition = Position.Left,
+		sourcePosition = Position.Right,
+	}: NodeProps = $props();
+</script>
+
+<Handle type="target" position={targetPosition} />
+
+<div
+	class="rounded-box bg-base-100 border-base-content/10 flex flex-col items-center gap-1 border p-3"
+>
+	<FactoryIcon size="28" class="text-secondary/70" />
+
+	<span class="font-bold">Recipe Name</span>
+
+	<ul class="text-base-content/80 flex flex-col gap-1 text-xs">
+		{#snippet factory(name: string, amount: number, effectStrings: string[])}
+			<li>
+				<span class="text-base-content/50">{amount}x</span>
+				{name}
+
+				<p class="text-base-content/50 text-[0.5rem] font-semibold uppercase">
+					{effectStrings.join(', ')}
+				</p>
+			</li>
+		{/snippet}
+
+		{@render factory('Factory Name', 2, ['effect'])}
+	</ul>
+</div>
+
+<Handle type="source" position={sourcePosition} />


### PR DESCRIPTION
Currently, only dummy data is displayed.

The node's width and height is variable based on the content. This might cause issues when calculating the layout.

Closes #17 