### PR TITLE
feat: add settings

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Navbar from '@/lib/components/Navbar.svelte';
+	import ThemeHandler from '@/lib/components/ThemeHandler.svelte';
 	import Router from '@/lib/router/Router.svelte';
 	import routes from '@/routes';
 </script>
@@ -8,4 +9,6 @@
 	<Navbar />
 
 	<Router {routes} />
+
+	<ThemeHandler />
 </main>

--- a/src/app.css
+++ b/src/app.css
@@ -3,5 +3,7 @@
 	/* prevent a warning, see https://github.com/saadeghi/daisyui/issues/3882 */
 	exclude: properties;
 
-	themes: light --default;
+	themes:
+		light --default,
+		dark --prefersdark;
 }

--- a/src/lib/components/ThemeHandler.svelte
+++ b/src/lib/components/ThemeHandler.svelte
@@ -1,0 +1,15 @@
+<!--
+	@component
+	Updating the theme from the settings store
+ -->
+
+<script lang="ts">
+	import settings from '@/lib/stores/settings.svelte';
+
+	$effect(() => {
+		// for the system theme to take effect, we need to explicitly remove the data-theme attribute
+		if (!$settings.theme) return document.documentElement.removeAttribute('data-theme');
+
+		document.documentElement.setAttribute('data-theme', $settings.theme || '');
+	});
+</script>

--- a/src/lib/components/settings/SettingsCard.svelte
+++ b/src/lib/components/settings/SettingsCard.svelte
@@ -1,5 +1,37 @@
+<script lang="ts">
+	import settings from '@/lib/stores/settings.svelte';
+</script>
+
 <article class="bg-base-200 card card-lg card-border mx-auto w-3xl max-w-11/12 shadow-md">
 	<div class="card-body">
 		<h2 class="card-title">Settings</h2>
+
+		<fieldset class="fieldset">
+			<legend class="fieldset-legend">Theme</legend>
+
+			<div class="join">
+				<input
+					type="radio"
+					bind:group={$settings.theme}
+					value=""
+					aria-label="System Default"
+					class="join-item btn"
+				/>
+				<input
+					type="radio"
+					bind:group={$settings.theme}
+					value="light"
+					aria-label="Light"
+					class="join-item btn"
+				/>
+				<input
+					type="radio"
+					bind:group={$settings.theme}
+					value="dark"
+					aria-label="Dark"
+					class="join-item btn"
+				/>
+			</div>
+		</fieldset>
 	</div>
 </article>

--- a/src/lib/components/settings/SettingsCard.svelte
+++ b/src/lib/components/settings/SettingsCard.svelte
@@ -1,0 +1,5 @@
+<article class="bg-base-200 card card-lg card-border mx-auto w-3xl max-w-11/12 shadow-md">
+	<div class="card-body">
+		<h2 class="card-title">Settings</h2>
+	</div>
+</article>

--- a/src/lib/pages/Settings.svelte
+++ b/src/lib/pages/Settings.svelte
@@ -1,3 +1,7 @@
+<script lang="ts">
+	import SettingsCard from '@/lib/components/settings/SettingsCard.svelte';
+</script>
+
 <div class="p-8 pt-28">
-	<h2 class="text-2xl font-bold">Settings</h2>
+	<SettingsCard />
 </div>

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -1,0 +1,25 @@
+import { writable } from 'svelte/store';
+
+const SETTINGS_LOCAL_STORAGE_KEY = 'settings';
+
+const settings = writable<{}>({});
+
+// set initial saved state
+setSettingsFromLocalStorage();
+
+// update localStorage on every settings update
+settings.subscribe(x => {
+	if (!localStorage) return;
+
+	localStorage.setItem(SETTINGS_LOCAL_STORAGE_KEY, JSON.stringify(x));
+});
+
+export default settings;
+
+function setSettingsFromLocalStorage() {
+	if (!localStorage) return;
+
+	const settingsString = localStorage.getItem(SETTINGS_LOCAL_STORAGE_KEY);
+
+	if (settingsString) settings.set(JSON.parse(settingsString));
+}

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -2,7 +2,7 @@ import { writable } from 'svelte/store';
 
 const SETTINGS_LOCAL_STORAGE_KEY = 'settings';
 
-const settings = writable<{}>({});
+const settings = writable<{ theme?: '' | 'dark' | 'light' }>({});
 
 // set initial saved state
 setSettingsFromLocalStorage();


### PR DESCRIPTION
- add global (writable) settings store
- add input on settings card
- add persistence via localStorage

Settings:

- add theme setting
- add `dark` theme

Closes #23