### PR TITLE
feat(ui): add factory creationmanagement UI skeleton

### DIFF
--- a/src/lib/components/profile/FactoryDetails.svelte
+++ b/src/lib/components/profile/FactoryDetails.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import ItemSelect from '@/lib/components/shared/ItemSelect.svelte';
+	import Item from '@/lib/models/item';
+
+	let inputs = $state<{ item: Item; amount: number }[]>([]),
+		outputs = $state<{ item: Item; amount: number }[]>([]);
+
+	function calculate() {
+		//
+	}
+</script>
+
+<div
+	class="fixed top-24 bottom-4 left-4 z-10 h-fit max-h-[calc(100%-var(--spacing)*28)] w-80 overflow-auto"
+>
+	<div class="rounded-box bg-base-200 p-2">
+		<h2 class="text-xl font-bold">This Factory</h2>
+
+		<fieldset class="fieldset bg-base-100 border-base-300 rounded-box min-w-0 border p-4">
+			<legend class="fieldset-legend">Inputs</legend>
+
+			<ItemSelect bind:items={inputs} />
+		</fieldset>
+
+		<fieldset class="fieldset bg-base-100 border-base-300 rounded-box border p-4">
+			<legend class="fieldset-legend">Outputs</legend>
+
+			<ItemSelect bind:items={outputs} />
+		</fieldset>
+
+		<div class="flex flex-row-reverse gap-2 pt-2">
+			<button onclick={calculate} class="btn btn-primary btn-soft">Calculate</button>
+		</div>
+	</div>
+</div>

--- a/src/lib/components/profile/FactoryDetails.svelte
+++ b/src/lib/components/profile/FactoryDetails.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import ItemSelect from '@/lib/components/shared/ItemSelect.svelte';
 	import Item from '@/lib/models/item';
+	import { ZapIcon } from '@lucide/svelte';
 
 	let inputs = $state<{ item: Item; amount: number }[]>([]),
 		outputs = $state<{ item: Item; amount: number }[]>([]);
@@ -27,6 +28,15 @@
 
 			<ItemSelect bind:items={outputs} />
 		</fieldset>
+
+		<ul class="py-2">
+			<li class="px-2">
+				<ZapIcon size="18" class="text-base-content/50 inline" />
+				<span class="sr-only">Electricity</span>
+				<b class="font-bold">13</b>
+				<span class="text-base-content/80">MW</span>
+			</li>
+		</ul>
 
 		<div class="flex flex-row-reverse gap-2 pt-2">
 			<button onclick={calculate} class="btn btn-primary btn-soft">Calculate</button>

--- a/src/lib/components/profile/ProfileLayout.svelte
+++ b/src/lib/components/profile/ProfileLayout.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
+	import FactoryDetails from '@/lib/components/profile/FactoryDetails.svelte';
 	import OverviewWindow from '@/lib/components/profile/OverviewWindow.svelte';
 	import ProfileStage from '@/lib/components/profile/ProfileStage.svelte';
 </script>
+
+<FactoryDetails />
 
 <OverviewWindow />
 

--- a/src/lib/components/shared/ItemSelect.svelte
+++ b/src/lib/components/shared/ItemSelect.svelte
@@ -1,0 +1,100 @@
+<!--
+@component
+Renders a item multi-select with amount. Item selection via dialog.
+-->
+
+<script lang="ts">
+	import Dialog from '@/lib/components/shared/Dialog.svelte';
+	import Search from '@/lib/components/shared/Search.svelte';
+	import Item from '@/lib/models/item';
+	import active from '@/lib/stores/active.svelte';
+	import { AnvilIcon, PlusIcon, Trash2Icon } from '@lucide/svelte';
+
+	let { items = $bindable([]) }: { items: { item: Item; amount: number }[] } = $props();
+
+	let dialog = $state<HTMLDialogElement>();
+
+	let searchQuery = $state('');
+	const filteredItems = $derived(
+		active.profile?.items.filter(
+			x =>
+				x.getDisplayName().toLowerCase().includes(searchQuery.toLowerCase()) ||
+				x.id.toLowerCase().includes(searchQuery.toLowerCase()) ||
+				x.category.includes(searchQuery.toLowerCase()),
+		) ?? [],
+	);
+
+	function openAddItemsDialog() {
+		dialog?.showModal();
+	}
+
+	function addItemCreator(id: string) {
+		return () => {
+			const item = active.profile?.getItemById(id);
+			if (!item) return;
+
+			items = [...items, { item, amount: 1 }];
+		};
+	}
+
+	function removeItemAtIndexCreator(i: number) {
+		return () => {
+			items = items.toSpliced(i, 1);
+		};
+	}
+</script>
+
+<div>
+	{#each items as item, i}
+		<div class="flex min-w-0 gap-2 truncate pb-2">
+			<p class="grow content-center truncate text-sm font-semibold">
+				<!-- TODO properly truncate -->
+				{item.item.getDisplayName()}
+			</p>
+
+			<input type="number" bind:value={item.amount} min="1" class="input input-sm w-16" />
+
+			<button
+				onclick={removeItemAtIndexCreator(i)}
+				class="btn btn-sm btn-square btn-error btn-soft"
+			>
+				<span class="sr-only">Remove Item</span>
+				<Trash2Icon size="18" />
+			</button>
+		</div>
+	{/each}
+
+	<button onclick={openAddItemsDialog} class="link">Add items</button>
+</div>
+
+<Dialog bind:dialog>
+	<h3 class="text-lg font-bold">Add Items</h3>
+
+	<Search bind:value={searchQuery} />
+
+	<ul class="list h-96 max-h-full overflow-auto">
+		{#each filteredItems as item (item.id)}
+			<li class="list-row">
+				<AnvilIcon class="m-2" />
+
+				<div>
+					<div>{item.getDisplayName()}</div>
+					<div class="text-xs font-semibold uppercase opacity-60">
+						{item.category}
+					</div>
+				</div>
+
+				<div>
+					<button
+						onclick={addItemCreator(item.id)}
+						class="btn btn-square btn-soft btn-primary"
+					>
+						<PlusIcon />
+					</button>
+				</div>
+			</li>
+		{:else}
+			<p class="p-4 text-center">No items found.</p>
+		{/each}
+	</ul>
+</Dialog>

--- a/src/lib/components/shared/Search.svelte
+++ b/src/lib/components/shared/Search.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <div class="bg-base-100 sticky top-0 z-10 p-3">
-	<label class="input input-sm">
+	<label class="input input-sm w-full">
 		<SearchIcon size="14" />
 
 		<input type="search" bind:value placeholder="Search" class="grow" />


### PR DESCRIPTION
Add the factory creation component to the left of the screen:
<img width="342" height="398" alt="image" src="https://github.com/user-attachments/assets/4d9fb3f4-15a9-469a-ae3a-250084714d72" />

This should serve as the base for the user to interact with factory chain calculation and receive stats about the calculated factory.

IMO this looks like the right direction to proceed. What do you think?
@melo-afk @philxws692

Closes #42