### PR TITLE
fix(ui): shrinking icons

### DIFF
--- a/src/lib/components/profile/ItemOverview.svelte
+++ b/src/lib/components/profile/ItemOverview.svelte
@@ -23,7 +23,7 @@
 			<details class="collapse-arrow list-col-grow collapse" name="accordion-item-overview">
 				<summary class="collapse-title select-none">
 					<div class="flex">
-						<AnvilIcon size="24" class="m-2" />
+						<AnvilIcon size="24" class="m-2 shrink-0" />
 
 						<div>
 							<div>{item.getDisplayName()}</div>

--- a/src/lib/components/profile/MachineOverview.svelte
+++ b/src/lib/components/profile/MachineOverview.svelte
@@ -26,7 +26,7 @@
 			>
 				<summary class="collapse-title select-none">
 					<div class="flex">
-						<HammerIcon size="24" class="m-2" />
+						<HammerIcon size="24" class="m-2 shrink-0" />
 
 						<div>
 							<div>{machine.getDisplayName()}</div>

--- a/src/lib/components/profile/MachineOverview.svelte
+++ b/src/lib/components/profile/MachineOverview.svelte
@@ -31,7 +31,7 @@
 						<div>
 							<div>{machine.getDisplayName()}</div>
 							<div class="text-xs font-semibold uppercase opacity-60">
-								{machine.recipeCategories}
+								{machine.recipeCategories.join(', ')}
 							</div>
 						</div>
 					</div>

--- a/src/lib/components/profile/RecipeOverview.svelte
+++ b/src/lib/components/profile/RecipeOverview.svelte
@@ -35,7 +35,7 @@
 			<details class="collapse-arrow list-col-grow collapse" name="accordion-recipe-overview">
 				<summary class="collapse-title select-none">
 					<div class="flex">
-						<TestTubeDiagonalIcon size="24" class="m-2" />
+						<TestTubeDiagonalIcon size="24" class="m-2 shrink-0" />
 
 						<div>
 							<div>{recipe.getDisplayName()}</div>


### PR DESCRIPTION
Fixed by adding `shrink-0` to all Overview profile components.

Closes #46 